### PR TITLE
Add min_id_length in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ AMPLITUDE_INCLUDE_GROUP_DATA = False
 *Note: If you want to include user or group data you must ensure the [Django auth is setup correctly](https://docs.djangoproject.com/en/3.0/topics/auth/#installation). This includes adding `django.contrib.auth` and `django.contrib.contenttypes` to `INSTALLED_APPS` and `django.contrib.auth.middleware.AuthenticationMiddleware` to `MIDDLEWARE`*.
 
 
+For more information on the above settings see the [configuration settings](#configuration-settings) section.
+
+
+
 ## Usage
 
 ### Page view events
@@ -142,3 +146,29 @@ amplitude.location_data_from_ip_address(ip_address)  # Gets location data from I
 
 * `user_properties_from_request` will return an empty dict if `AMPLITUDE_INCLUDE_USER_DATA` is `False`
 * `group_from_request` will return an empty dict if `AMPLITUDE_INCLUDE_GROUP_DATA` is `False`
+
+
+#### Configuration settings
+
+Below are the different settings that can be overridden. To do so place the setting into your `settings.py`.
+
+```python
+# This variable is required when amplitude is added to INSTALLED_APPS
+AMPLITUDE_API_KEY = '<amplitude-project-api-key>'
+
+# If the users Django user information is included in the Amplitude event.
+# This includes - username, email, full_name, is_staff, is_superuser
+AMPLITUDE_INCLUDE_USER_DATA = False
+
+# If the groups the user is a member of is included in the Amplitude event.
+# A list of the group names will be sent in the request.
+AMPLITUDE_INCLUDE_GROUP_DATA = False
+
+# A list of URLs which `SendPageViewEvent` middleward should not run for.
+# Each item in the list can be either a URL or url name
+AMPLITUDE_IGNORE_URLS = ['home', '/please/ignore/']
+
+# The minimum permitted length for user_id & device_id fields
+# https://developers.amplitude.com/docs/http-api-v2#properties-2
+AMPLITUDE_MIN_ID_LENGTH = None
+```

--- a/amplitude/amplitude.py
+++ b/amplitude/amplitude.py
@@ -31,6 +31,7 @@ class Amplitude():
         api_key: str = None,
         include_user_data: bool = None,
         include_group_data: bool = None,
+        min_id_length: int = None,
     ):
         if not api_key:
             api_key = app_settings.API_KEY
@@ -38,11 +39,14 @@ class Amplitude():
             include_user_data = app_settings.INCLUDE_USER_DATA
         if include_group_data is None:
             include_group_data = app_settings.INCLUDE_GROUP_DATA
+        if not min_id_length:
+            min_id_length = app_settings.MIN_ID_LENGTH
 
         self.url = 'https://api.amplitude.com/2/httpapi'
         self.api_key = api_key
         self.include_user_data = include_user_data
         self.include_group_data = include_group_data
+        self.min_id_length = min_id_length
 
     def send_events(self, events: List[Dict[str, Any]]) -> dict:
         """
@@ -57,6 +61,10 @@ class Amplitude():
                 'api_key': self.api_key
             }
         }
+        if self.min_id_length is not None:
+            kwargs['json']['options'] = {
+                'min_id_length': self.min_id_length
+            }
         response = httpx.request(**kwargs)
         try:
             response.raise_for_status()

--- a/amplitude/settings.py
+++ b/amplitude/settings.py
@@ -12,6 +12,10 @@ if not isinstance(IGNORE_URLS, list):
     error = '"AMPLITUDE_IGNORE_URLS" must be a list of URLs or URL names'
     raise ImproperlyConfigured(error)
 
+MIN_ID_LENGTH = getattr(settings, 'AMPLITUDE_MIN_ID_LENGTH', None)
+if MIN_ID_LENGTH and not isinstance(MIN_ID_LENGTH, int):
+    raise ImproperlyConfigured('"AMPLITUDE_MIN_ID_LENGTH" must be an integer')
+
 installed_apps = getattr(settings, 'INSTALLED_APPS')
 middleware = getattr(settings, 'MIDDLEWARE')
 missing_session_settings = (

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -66,3 +66,12 @@ def test_ignore_urls(settings):
         from amplitude import settings as appsettings
         reload(appsettings)
     error.match('"AMPLITUDE_IGNORE_URLS" must be a list of URLs or URL names')
+
+
+def test_min_id_length(settings):
+    settings.AMPLITUDE_MIN_ID_LENGTH = 'test'
+
+    with pytest.raises(ImproperlyConfigured) as error:
+        from amplitude import settings as appsettings
+        reload(appsettings)
+    error.match('"AMPLITUDE_MIN_ID_LENGTH" must be an integer')


### PR DESCRIPTION
According to [documentation](https://developers.amplitude.com/docs/http-api-v2#properties-2), we could set `min_id_length` in settings to support short user identifiers.