### PR TITLE
Catch GeoIP2Error

### DIFF
--- a/amplitude/amplitude.py
+++ b/amplitude/amplitude.py
@@ -206,7 +206,11 @@ class Amplitude():
         # https://pypi.org/project/geoip2/
         # from django.contrib.gis.geoip2 import GeoIP2
         g = GeoIP2()
-        location = g.city(ip_address)
+        try:
+            location = g.city(ip_address)
+        except RuntimeError:
+            # Catch exceptions like `AddressNotFoundError`
+            return location_data
         location_data['country'] = location['country_name']
         location_data['city'] = location['city']
         lat_lon = g.lat_lon(ip_address)

--- a/tests/test_amplitude.py
+++ b/tests/test_amplitude.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.utils import translation
 from httpx import HTTPError
 
-from amplitude import Amplitude, settings
+from amplitude import Amplitude, settings, amplitude as amplitude_module
 from amplitude.amplitude import AmplitudeException
 
 from .fixtures import user  # NOQA: F401
@@ -423,4 +423,14 @@ def test_device_data_no_meta(rf):
 
 def test_location_data_from_ip_address_no_meta(rf):
     location_data = amplitude.location_data_from_ip_address(ip_address='')
+    assert location_data == {}
+
+
+def test_location_data_with_error(mocker):
+    mock = mocker.Mock()
+    mock.return_value.city.side_effect = RuntimeError()
+    amplitude_module.GeoIP2 = mock
+    mocker.patch('amplitude.amplitude.CAN_GEOIP', True)
+    location_data = amplitude.location_data_from_ip_address(ip_address='127.0.0.1')
+    mock.return_value.city.assert_called_once()
     assert location_data == {}


### PR DESCRIPTION
Catch exceptions like `AddressNotFoundError` and return an empty dict.