### PR TITLE
Apply min_id_length to user_id

### DIFF
--- a/amplitude/amplitude.py
+++ b/amplitude/amplitude.py
@@ -120,7 +120,10 @@ class Amplitude():
             event['event_properties'] = self.event_properties_from_request(request)  # NOQA: E501
 
         try:
-            event['user_id'] = f'{request.user.pk:05}'
+            if self.min_id_length:
+                event['user_id'] = f'{request.user.pk:0{self.min_id_length}}'
+            else:
+                event['user_id'] = f'{request.user.pk:05}'
         except (AttributeError, TypeError):
             pass
         event['user_properties'] = self.user_properties_from_request(request)

--- a/tests/test_amplitude.py
+++ b/tests/test_amplitude.py
@@ -260,6 +260,25 @@ def test_build_event_data_with_kwargs(rf):
     assert event['insert_id'] == insert_id
 
 
+def test_build_event_data_with_min_id_length(rf, settings, user):
+    settings.AMPLITUDE_MIN_ID_LENGTH = 2
+    from amplitude import settings as appsettings
+    reload(appsettings)
+
+    amplitude = Amplitude()
+    request = rf.get('/')
+    request.user = user()
+    request.user.pk = 1
+    SessionMiddleware(fake_get_response).process_request(request)
+    request.session.save()
+
+    event = amplitude.build_event_data(
+        request=request,
+        event_type='event type',
+    )
+    assert event['user_id'] == '01'
+
+
 def test_clean_event():
     event = {
         '1': {


### PR DESCRIPTION
Apply min_id_length to user_id when building event data.
Might need to apply the limit to device_id as well if the min length is longer than uuid's length, but it may be not practical since we're using uuid4 to generate device_id.